### PR TITLE
Disable Actuator HTTP Observations

### DIFF
--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/web/reactive/WebFluxObservationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/web/reactive/WebFluxObservationAutoConfiguration.java
@@ -69,16 +69,14 @@ public class WebFluxObservationAutoConfiguration {
 		this.observationProperties = observationProperties;
 	}
 
-	public ServerHttpObservationFilter webfluxObservationFilter(ObservationRegistry registry,
-			ObjectProvider<ServerRequestObservationConvention> customConvention) {
+	public ServerHttpObservationFilter webfluxObservationFilter(ObservationRegistry registry, ObjectProvider customConvention) {
 		String name = this.observationProperties.getHttp().getServer().getRequests().getName();
 		ServerRequestObservationConvention convention = customConvention
 				.getIfAvailable(() -> new DefaultServerRequestObservationConvention(name));
 		return new ServerHttpObservationFilter(registry, convention);
 	}
 
-	public MeterFilter metricsHttpServerUriTagFilter(MetricsProperties metricsProperties,
-			ObservationProperties observationProperties) {
+	public MeterFilter metricsHttpServerUriTagFilter(MetricsProperties metricsProperties, ObservationProperties observationProperties) {
 		String name = observationProperties.getHttp().getServer().getRequests().getName();
 		MeterFilter filter = new OnlyOnceLoggingDenyMeterFilter(
 				() -> "Reached the maximum number of URI tags for '%s'.".formatted(name));
@@ -86,8 +84,7 @@ public class WebFluxObservationAutoConfiguration {
 				filter);
 	}
 
-	public ObservationPredicate actuatorWebEndpointObservationPredicate(WebFluxProperties webFluxProperties,
-			PathMappedEndpoints pathMappedEndpoints) {
+	public ObservationPredicate actuatorWebEndpointObservationPredicate(WebFluxProperties webFluxProperties, PathMappedEndpoints pathMappedEndpoints) {
 		return (name, context) -> {
 			if (context instanceof ServerRequestObservationContext serverContext) {
 				String endpointPath = getEndpointPath(webFluxProperties, pathMappedEndpoints);
@@ -98,8 +95,7 @@ public class WebFluxObservationAutoConfiguration {
 
 	}
 
-	private static String getEndpointPath(WebFluxProperties webFluxProperties,
-			PathMappedEndpoints pathMappedEndpoints) {
+	private static String getEndpointPath(WebFluxProperties webFluxProperties, PathMappedEndpoints pathMappedEndpoints) {
 		String webFluxBasePath = getWebFluxBasePath(webFluxProperties);
 		return Path.of(webFluxBasePath, pathMappedEndpoints.getBasePath()).toString();
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/web/reactive/WebFluxObservationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/web/reactive/WebFluxObservationAutoConfiguration.java
@@ -84,6 +84,16 @@ public class WebFluxObservationAutoConfiguration {
 				filter);
 	}
 
+	public MeterFilter metricsHttpServerUriTagFilter(MetricsProperties metricsProperties) {
+		String name = observationProperties.getHttp().getServer().getRequests().getName();
+		MeterFilter filter = new OnlyOnceLoggingDenyMeterFilter(
+				() -> "Reached the maximum number of URI tags for '%s'.".formatted(name));
+		MeterFilter filter = new OnlyOnceLoggingDenyMeterFilter(
+				() -> "Reached the maximum number of URI tags for '%s'.".formatted(name));
+		return MeterFilter.maximumAllowableTags(name, "uri", metricsProperties.getWeb().getServer().getMaxUriTags(),
+				filter);
+	}
+
 	public ObservationPredicate actuatorWebEndpointObservationPredicate(WebFluxProperties webFluxProperties, PathMappedEndpoints pathMappedEndpoints) {
 		return (name, context) -> {
 			if (context instanceof ServerRequestObservationContext serverContext) {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/web/reactive/WebFluxObservationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/web/reactive/WebFluxObservationAutoConfiguration.java
@@ -16,24 +16,40 @@
 
 package org.springframework.boot.actuate.autoconfigure.observation.web.reactive;
 
+import java.nio.file.Path;
+
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationPredicate;
 import io.micrometer.observation.ObservationRegistry;
 
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsProperties;
 import org.springframework.boot.actuate.autoconfigure.metrics.OnlyOnceLoggingDenyMeterFilter;
 import org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleMetricsExportAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.observation.ObservationAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.observation.ObservationProperties;
+import org.springframework.boot.actuate.endpoint.web.PathMappedEndpoints;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.web.reactive.WebFluxProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.server.reactive.observation.DefaultServerRequestObservationConvention;
+import org.springframework.http.server.reactive.observation.ServerRequestObservationContext;
+import org.springframework.http.server.reactive.observation.ServerRequestObservationConvention;
+import org.springframework.web.filter.reactive.ServerHttpObservationFilter;
 
 /**
  * {@link EnableAutoConfiguration Auto-configuration} for instrumentation of Spring
@@ -42,24 +58,80 @@ import org.springframework.core.annotation.Order;
  * @author Brian Clozel
  * @author Jon Schneider
  * @author Dmytro Nosan
+ * @author Jonatan Ivanov
  * @since 3.0.0
  */
-@AutoConfiguration(after = { SimpleMetricsExportAutoConfiguration.class, ObservationAutoConfiguration.class })
-@ConditionalOnClass({ Observation.class, MeterRegistry.class })
-@ConditionalOnBean({ ObservationRegistry.class, MeterRegistry.class })
+@AutoConfiguration(after = { MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class,
+		SimpleMetricsExportAutoConfiguration.class, ObservationAutoConfiguration.class })
+@ConditionalOnClass(Observation.class)
+@ConditionalOnBean(ObservationRegistry.class)
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)
 @EnableConfigurationProperties({ MetricsProperties.class, ObservationProperties.class })
+@SuppressWarnings("removal")
 public class WebFluxObservationAutoConfiguration {
 
+	private final ObservationProperties observationProperties;
+
+	public WebFluxObservationAutoConfiguration(ObservationProperties observationProperties) {
+		this.observationProperties = observationProperties;
+	}
+
 	@Bean
-	@Order(0)
-	MeterFilter metricsHttpServerUriTagFilter(MetricsProperties metricsProperties,
-			ObservationProperties observationProperties) {
-		String name = observationProperties.getHttp().getServer().getRequests().getName();
-		MeterFilter filter = new OnlyOnceLoggingDenyMeterFilter(
-				() -> "Reached the maximum number of URI tags for '%s'.".formatted(name));
-		return MeterFilter.maximumAllowableTags(name, "uri", metricsProperties.getWeb().getServer().getMaxUriTags(),
-				filter);
+	@ConditionalOnMissingBean(ServerHttpObservationFilter.class)
+	@Order(Ordered.HIGHEST_PRECEDENCE + 1)
+	public ServerHttpObservationFilter webfluxObservationFilter(ObservationRegistry registry,
+			ObjectProvider<ServerRequestObservationConvention> customConvention) {
+		String name = this.observationProperties.getHttp().getServer().getRequests().getName();
+		ServerRequestObservationConvention convention = customConvention
+				.getIfAvailable(() -> new DefaultServerRequestObservationConvention(name));
+		return new ServerHttpObservationFilter(registry, convention);
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnClass(MeterRegistry.class)
+	@ConditionalOnBean(MeterRegistry.class)
+	static class MeterFilterConfiguration {
+
+		@Bean
+		@Order(0)
+		MeterFilter metricsHttpServerUriTagFilter(MetricsProperties metricsProperties,
+				ObservationProperties observationProperties) {
+			String name = observationProperties.getHttp().getServer().getRequests().getName();
+			MeterFilter filter = new OnlyOnceLoggingDenyMeterFilter(
+					() -> "Reached the maximum number of URI tags for '%s'.".formatted(name));
+			return MeterFilter.maximumAllowableTags(name, "uri", metricsProperties.getWeb().getServer().getMaxUriTags(),
+					filter);
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnProperty(value = "management.observations.http.server.actuator.enabled", havingValue = "false")
+	static class ActuatorWebEndpointObservationConfiguration {
+
+		@Bean
+		ObservationPredicate actuatorWebEndpointObservationPredicate(WebFluxProperties webFluxProperties,
+				PathMappedEndpoints pathMappedEndpoints) {
+			return (name, context) -> {
+				if (context instanceof ServerRequestObservationContext serverContext) {
+					String endpointPath = getEndpointPath(webFluxProperties, pathMappedEndpoints);
+					return !serverContext.getCarrier().getURI().getPath().startsWith(endpointPath);
+				}
+				return true;
+			};
+
+		}
+
+		private static String getEndpointPath(WebFluxProperties webFluxProperties,
+				PathMappedEndpoints pathMappedEndpoints) {
+			String webFluxBasePath = getWebFluxBasePath(webFluxProperties);
+			return Path.of(webFluxBasePath, pathMappedEndpoints.getBasePath()).toString();
+		}
+
+		private static String getWebFluxBasePath(WebFluxProperties webFluxProperties) {
+			return (webFluxProperties.getBasePath() != null) ? webFluxProperties.getBasePath() : "";
+		}
+
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/web/reactive/WebFluxObservationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/web/reactive/WebFluxObservationAutoConfiguration.java
@@ -61,13 +61,6 @@ import org.springframework.web.filter.reactive.ServerHttpObservationFilter;
  * @author Jonatan Ivanov
  * @since 3.0.0
  */
-@AutoConfiguration(after = { MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class,
-		SimpleMetricsExportAutoConfiguration.class, ObservationAutoConfiguration.class })
-@ConditionalOnClass(Observation.class)
-@ConditionalOnBean(ObservationRegistry.class)
-@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.REACTIVE)
-@EnableConfigurationProperties({ MetricsProperties.class, ObservationProperties.class })
-@SuppressWarnings("removal")
 public class WebFluxObservationAutoConfiguration {
 
 	private final ObservationProperties observationProperties;
@@ -76,9 +69,6 @@ public class WebFluxObservationAutoConfiguration {
 		this.observationProperties = observationProperties;
 	}
 
-	@Bean
-	@ConditionalOnMissingBean(ServerHttpObservationFilter.class)
-	@Order(Ordered.HIGHEST_PRECEDENCE + 1)
 	public ServerHttpObservationFilter webfluxObservationFilter(ObservationRegistry registry,
 			ObjectProvider<ServerRequestObservationConvention> customConvention) {
 		String name = this.observationProperties.getHttp().getServer().getRequests().getName();
@@ -87,13 +77,8 @@ public class WebFluxObservationAutoConfiguration {
 		return new ServerHttpObservationFilter(registry, convention);
 	}
 
-	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnClass(MeterRegistry.class)
-	@ConditionalOnBean(MeterRegistry.class)
 	static class MeterFilterConfiguration {
 
-		@Bean
-		@Order(0)
 		MeterFilter metricsHttpServerUriTagFilter(MetricsProperties metricsProperties,
 				ObservationProperties observationProperties) {
 			String name = observationProperties.getHttp().getServer().getRequests().getName();
@@ -105,11 +90,8 @@ public class WebFluxObservationAutoConfiguration {
 
 	}
 
-	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnProperty(value = "management.observations.http.server.actuator.enabled", havingValue = "false")
 	static class ActuatorWebEndpointObservationConfiguration {
 
-		@Bean
 		ObservationPredicate actuatorWebEndpointObservationPredicate(WebFluxProperties webFluxProperties,
 				PathMappedEndpoints pathMappedEndpoints) {
 			return (name, context) -> {

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/web/servlet/WebMvcObservationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/web/servlet/WebMvcObservationAutoConfiguration.java
@@ -68,6 +68,7 @@ import org.springframework.web.servlet.DispatcherServlet;
  */
 public class WebMvcObservationAutoConfiguration {
 
+	@Bean
 	public FilterRegistrationBean<ServerHttpObservationFilter> webMvcObservationFilter(ObservationRegistry registry, ObjectProvider customConvention, ObservationProperties observationProperties) {
 		String name = observationProperties.getHttp().getServer().getRequests().getName();
 		ServerRequestObservationConvention convention = customConvention
@@ -79,6 +80,7 @@ public class WebMvcObservationAutoConfiguration {
 		return registration;
 	}
 
+	@Bean
 	public MeterFilter metricsHttpServerUriTagFilter(ObservationProperties observationProperties, MetricsProperties metricsProperties) {
 		String name = observationProperties.getHttp().getServer().getRequests().getName();
 		MeterFilter filter = new OnlyOnceLoggingDenyMeterFilter(

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/web/servlet/WebMvcObservationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/web/servlet/WebMvcObservationAutoConfiguration.java
@@ -66,17 +66,8 @@ import org.springframework.web.servlet.DispatcherServlet;
  * @author Jonatan Ivanov
  * @since 3.0.0
  */
-@AutoConfiguration(after = { MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class,
-		SimpleMetricsExportAutoConfiguration.class, ObservationAutoConfiguration.class })
-@ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
-@ConditionalOnClass({ DispatcherServlet.class, Observation.class })
-@ConditionalOnBean(ObservationRegistry.class)
-@EnableConfigurationProperties({ MetricsProperties.class, ObservationProperties.class, ServerProperties.class,
-		WebMvcProperties.class })
 public class WebMvcObservationAutoConfiguration {
 
-	@Bean
-	@ConditionalOnMissingFilterBean
 	public FilterRegistrationBean<ServerHttpObservationFilter> webMvcObservationFilter(ObservationRegistry registry,
 			ObjectProvider<ServerRequestObservationConvention> customConvention,
 			ObservationProperties observationProperties) {
@@ -90,13 +81,8 @@ public class WebMvcObservationAutoConfiguration {
 		return registration;
 	}
 
-	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnClass(MeterRegistry.class)
-	@ConditionalOnBean(MeterRegistry.class)
 	static class MeterFilterConfiguration {
 
-		@Bean
-		@Order(0)
 		MeterFilter metricsHttpServerUriTagFilter(ObservationProperties observationProperties,
 				MetricsProperties metricsProperties) {
 			String name = observationProperties.getHttp().getServer().getRequests().getName();
@@ -108,8 +94,6 @@ public class WebMvcObservationAutoConfiguration {
 
 	}
 
-	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnProperty(value = "management.observations.http.server.actuator.enabled", havingValue = "false")
 	static class ActuatorWebEndpointObservationConfiguration {
 
 		@Bean

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/web/servlet/WebMvcObservationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/web/servlet/WebMvcObservationAutoConfiguration.java
@@ -68,7 +68,9 @@ import org.springframework.web.servlet.DispatcherServlet;
  */
 public class WebMvcObservationAutoConfiguration {
 
-	@Bean
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnClass(MeterRegistry.class)
+	@ConditionalOnBean(MeterRegistry.class)
 	public FilterRegistrationBean<ServerHttpObservationFilter> webMvcObservationFilter(ObservationRegistry registry, ObjectProvider customConvention, ObservationProperties observationProperties) {
 		String name = observationProperties.getHttp().getServer().getRequests().getName();
 		ServerRequestObservationConvention convention = customConvention
@@ -79,8 +81,10 @@ public class WebMvcObservationAutoConfiguration {
 		registration.setDispatcherTypes(DispatcherType.REQUEST, DispatcherType.ASYNC);
 		return registration;
 	}
-
-	@Bean
+	
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnClass(MeterRegistry.class)
+	@ConditionalOnBean(MeterRegistry.class)
 	public MeterFilter metricsHttpServerUriTagFilter(ObservationProperties observationProperties, MetricsProperties metricsProperties) {
 		String name = observationProperties.getHttp().getServer().getRequests().getName();
 		MeterFilter filter = new OnlyOnceLoggingDenyMeterFilter(

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/web/servlet/WebMvcObservationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/web/servlet/WebMvcObservationAutoConfiguration.java
@@ -68,9 +68,7 @@ import org.springframework.web.servlet.DispatcherServlet;
  */
 public class WebMvcObservationAutoConfiguration {
 
-	public FilterRegistrationBean<ServerHttpObservationFilter> webMvcObservationFilter(ObservationRegistry registry,
-			ObjectProvider<ServerRequestObservationConvention> customConvention,
-			ObservationProperties observationProperties) {
+	public FilterRegistrationBean<ServerHttpObservationFilter> webMvcObservationFilter(ObservationRegistry registry, ObjectProvider customConvention, ObservationProperties observationProperties) {
 		String name = observationProperties.getHttp().getServer().getRequests().getName();
 		ServerRequestObservationConvention convention = customConvention
 				.getIfAvailable(() -> new DefaultServerRequestObservationConvention(name));
@@ -81,8 +79,7 @@ public class WebMvcObservationAutoConfiguration {
 		return registration;
 	}
 
-	public MeterFilter metricsHttpServerUriTagFilter(ObservationProperties observationProperties,
-			MetricsProperties metricsProperties) {
+	public MeterFilter metricsHttpServerUriTagFilter(ObservationProperties observationProperties, MetricsProperties metricsProperties) {
 		String name = observationProperties.getHttp().getServer().getRequests().getName();
 		MeterFilter filter = new OnlyOnceLoggingDenyMeterFilter(
 				() -> String.format("Reached the maximum number of URI tags for '%s'.", name));
@@ -90,8 +87,7 @@ public class WebMvcObservationAutoConfiguration {
 				filter);
 	}
 
-	public ObservationPredicate actuatorWebEndpointObservationPredicate(ServerProperties serverProperties,
-			WebMvcProperties webMvcProperties, PathMappedEndpoints pathMappedEndpoints) {
+	public ObservationPredicate actuatorWebEndpointObservationPredicate(ServerProperties serverProperties, WebMvcProperties webMvcProperties, PathMappedEndpoints pathMappedEndpoints) {
 		return (name, context) -> {
 			if (context instanceof ServerRequestObservationContext serverContext) {
 				String endpointPath = getEndpointPath(serverProperties, webMvcProperties, pathMappedEndpoints);
@@ -101,8 +97,7 @@ public class WebMvcObservationAutoConfiguration {
 		};
 	}
 
-	private static String getEndpointPath(ServerProperties serverProperties, WebMvcProperties webMvcProperties,
-			PathMappedEndpoints pathMappedEndpoints) {
+	private static String getEndpointPath(ServerProperties serverProperties, WebMvcProperties webMvcProperties, PathMappedEndpoints pathMappedEndpoints) {
 		String contextPath = getContextPath(serverProperties);
 		String servletPath = getServletPath(webMvcProperties);
 		return Path.of(contextPath, servletPath, pathMappedEndpoints.getBasePath()).toString();

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/web/servlet/WebMvcObservationAutoConfiguration.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/java/org/springframework/boot/actuate/autoconfigure/observation/web/servlet/WebMvcObservationAutoConfiguration.java
@@ -16,9 +16,12 @@
 
 package org.springframework.boot.actuate.autoconfigure.observation.web.servlet;
 
+import java.nio.file.Path;
+
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.config.MeterFilter;
 import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationPredicate;
 import io.micrometer.observation.ObservationRegistry;
 import jakarta.servlet.DispatcherType;
 
@@ -30,12 +33,17 @@ import org.springframework.boot.actuate.autoconfigure.metrics.OnlyOnceLoggingDen
 import org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleMetricsExportAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.observation.ObservationAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.observation.ObservationProperties;
+import org.springframework.boot.actuate.endpoint.web.PathMappedEndpoints;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.autoconfigure.web.ServerProperties.Servlet;
 import org.springframework.boot.autoconfigure.web.servlet.ConditionalOnMissingFilterBean;
+import org.springframework.boot.autoconfigure.web.servlet.WebMvcProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -43,6 +51,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.server.observation.DefaultServerRequestObservationConvention;
+import org.springframework.http.server.observation.ServerRequestObservationContext;
 import org.springframework.http.server.observation.ServerRequestObservationConvention;
 import org.springframework.web.filter.ServerHttpObservationFilter;
 import org.springframework.web.servlet.DispatcherServlet;
@@ -54,6 +63,7 @@ import org.springframework.web.servlet.DispatcherServlet;
  * @author Brian Clozel
  * @author Jon Schneider
  * @author Dmytro Nosan
+ * @author Jonatan Ivanov
  * @since 3.0.0
  */
 @AutoConfiguration(after = { MetricsAutoConfiguration.class, CompositeMeterRegistryAutoConfiguration.class,
@@ -61,7 +71,8 @@ import org.springframework.web.servlet.DispatcherServlet;
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
 @ConditionalOnClass({ DispatcherServlet.class, Observation.class })
 @ConditionalOnBean(ObservationRegistry.class)
-@EnableConfigurationProperties({ MetricsProperties.class, ObservationProperties.class })
+@EnableConfigurationProperties({ MetricsProperties.class, ObservationProperties.class, ServerProperties.class,
+		WebMvcProperties.class })
 public class WebMvcObservationAutoConfiguration {
 
 	@Bean
@@ -71,7 +82,7 @@ public class WebMvcObservationAutoConfiguration {
 			ObservationProperties observationProperties) {
 		String name = observationProperties.getHttp().getServer().getRequests().getName();
 		ServerRequestObservationConvention convention = customConvention
-			.getIfAvailable(() -> new DefaultServerRequestObservationConvention(name));
+				.getIfAvailable(() -> new DefaultServerRequestObservationConvention(name));
 		ServerHttpObservationFilter filter = new ServerHttpObservationFilter(registry, convention);
 		FilterRegistrationBean<ServerHttpObservationFilter> registration = new FilterRegistrationBean<>(filter);
 		registration.setOrder(Ordered.HIGHEST_PRECEDENCE + 1);
@@ -93,6 +104,41 @@ public class WebMvcObservationAutoConfiguration {
 					() -> String.format("Reached the maximum number of URI tags for '%s'.", name));
 			return MeterFilter.maximumAllowableTags(name, "uri", metricsProperties.getWeb().getServer().getMaxUriTags(),
 					filter);
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@ConditionalOnProperty(value = "management.observations.http.server.actuator.enabled", havingValue = "false")
+	static class ActuatorWebEndpointObservationConfiguration {
+
+		@Bean
+		ObservationPredicate actuatorWebEndpointObservationPredicate(ServerProperties serverProperties,
+				WebMvcProperties webMvcProperties, PathMappedEndpoints pathMappedEndpoints) {
+			return (name, context) -> {
+				if (context instanceof ServerRequestObservationContext serverContext) {
+					String endpointPath = getEndpointPath(serverProperties, webMvcProperties, pathMappedEndpoints);
+					return !serverContext.getCarrier().getRequestURI().startsWith(endpointPath);
+				}
+				return true;
+			};
+		}
+
+		private static String getEndpointPath(ServerProperties serverProperties, WebMvcProperties webMvcProperties,
+				PathMappedEndpoints pathMappedEndpoints) {
+			String contextPath = getContextPath(serverProperties);
+			String servletPath = getServletPath(webMvcProperties);
+			return Path.of(contextPath, servletPath, pathMappedEndpoints.getBasePath()).toString();
+		}
+
+		private static String getContextPath(ServerProperties serverProperties) {
+			Servlet servlet = serverProperties.getServlet();
+			return (servlet.getContextPath() != null) ? servlet.getContextPath() : "";
+		}
+
+		private static String getServletPath(WebMvcProperties webMvcProperties) {
+			WebMvcProperties.Servlet servletProperties = webMvcProperties.getServlet();
+			return (servletProperties.getPath() != null) ? servletProperties.getPath() : "";
 		}
 
 	}

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1606,13 +1606,6 @@
       }
     },
     {
-      "name": "management.metrics.export.signalfx.published-histogram-type",
-      "deprecation": {
-        "level": "error",
-        "replacement": "management.signalfx.metrics.export.published-histogram-type"
-      }
-    },
-    {
       "name": "management.metrics.export.signalfx.read-timeout",
       "type": "java.time.Duration",
       "deprecation": {
@@ -2062,8 +2055,10 @@
       }
     },
     {
-      "name": "management.otlp.metrics.export.base-time-unit",
-      "defaultValue": "milliseconds"
+      "name": "management.observations.http.server.actuator.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Whether to enable HTTP observations for actuator endpoints.",
+      "defaultValue": false
     },
     {
       "name": "management.otlp.tracing.compression",
@@ -2172,10 +2167,6 @@
     {
       "name": "management.server.ssl.trust-store-type",
       "description": "Type of the trust store."
-    },
-    {
-      "name": "management.signalfx.metrics.export.published-histogram-type",
-      "defaultValue": "default"
     },
     {
       "name": "management.simple.metrics.export.mode",

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/observation/web/reactive/WebFluxObservationAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/observation/web/reactive/WebFluxObservationAutoConfigurationTests.java
@@ -16,23 +16,43 @@
 
 package org.springframework.boot.actuate.autoconfigure.observation.web.reactive;
 
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
+import java.util.List;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistryAssert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import reactor.core.publisher.Mono;
 
+import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.reactive.WebFluxEndpointManagementContextConfiguration;
+import org.springframework.boot.actuate.autoconfigure.info.InfoEndpointAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.test.MetricsRun;
 import org.springframework.boot.actuate.autoconfigure.metrics.web.TestController;
 import org.springframework.boot.actuate.autoconfigure.observation.ObservationAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.web.reactive.HttpHandlerAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.reactive.ReactiveWebServerFactoryAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.reactive.WebFluxAutoConfiguration;
 import org.springframework.boot.test.context.assertj.AssertableReactiveWebApplicationContext;
 import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.boot.web.reactive.context.AnnotationConfigReactiveWebServerApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.server.reactive.observation.DefaultServerRequestObservationConvention;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.filter.reactive.ServerHttpObservationFilter;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,66 +62,291 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Brian Clozel
  * @author Dmytro Nosan
  * @author Madhura Bhave
+ * @author Jonatan Ivanov
  */
 @ExtendWith(OutputCaptureExtension.class)
+@SuppressWarnings("removal")
 class WebFluxObservationAutoConfigurationTests {
 
 	private final ReactiveWebApplicationContextRunner contextRunner = new ReactiveWebApplicationContextRunner()
-		.with(MetricsRun.simple())
-		.withConfiguration(
-				AutoConfigurations.of(ObservationAutoConfiguration.class, WebFluxObservationAutoConfiguration.class));
+			.with(MetricsRun.simple())
+			.withConfiguration(
+					AutoConfigurations.of(ObservationAutoConfiguration.class, WebFluxObservationAutoConfiguration.class));
+
+	@Test
+	void shouldProvideWebFluxObservationFilter() {
+		this.contextRunner.run((context) -> assertThat(context).hasSingleBean(ServerHttpObservationFilter.class));
+	}
+
+	@Test
+	void shouldProvideWebFluxObservationFilterOrdered() {
+		this.contextRunner.withBean(FirstWebFilter.class).withBean(ThirdWebFilter.class).run((context) -> {
+			List<WebFilter> webFilters = context.getBeanProvider(WebFilter.class).orderedStream().toList();
+			assertThat(webFilters.get(0)).isInstanceOf(FirstWebFilter.class);
+			assertThat(webFilters.get(1)).isInstanceOf(ServerHttpObservationFilter.class);
+			assertThat(webFilters.get(2)).isInstanceOf(ThirdWebFilter.class);
+		});
+	}
+
+	@Test
+	void shouldUseCustomConventionWhenAvailable() {
+		this.contextRunner.withUserConfiguration(CustomConventionConfiguration.class).run((context) -> {
+			assertThat(context).hasSingleBean(ServerHttpObservationFilter.class);
+			assertThat(context).getBean(ServerHttpObservationFilter.class)
+					.extracting("observationConvention")
+					.isInstanceOf(CustomConvention.class);
+		});
+	}
 
 	@Test
 	void afterMaxUrisReachedFurtherUrisAreDenied(CapturedOutput output) {
 		this.contextRunner.withUserConfiguration(TestController.class)
-			.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class, ObservationAutoConfiguration.class,
-					WebFluxAutoConfiguration.class))
-			.withPropertyValues("management.metrics.web.server.max-uri-tags=2")
-			.run((context) -> {
-				MeterRegistry registry = getInitializedMeterRegistry(context);
-				assertThat(registry.get("http.server.requests").meters()).hasSizeLessThanOrEqualTo(2);
-				assertThat(output).contains("Reached the maximum number of URI tags for 'http.server.requests'");
-			});
+				.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class, ObservationAutoConfiguration.class,
+						WebFluxAutoConfiguration.class))
+				.withPropertyValues("management.metrics.web.server.max-uri-tags=2")
+				.run((context) -> {
+					MeterRegistry registry = getInitializedMeterRegistry(context);
+					assertThat(registry.get("http.server.requests").meters()).hasSizeLessThanOrEqualTo(2);
+					assertThat(output).contains("Reached the maximum number of URI tags for 'http.server.requests'");
+				});
 	}
 
 	@Test
 	void afterMaxUrisReachedFurtherUrisAreDeniedWhenUsingCustomObservationName(CapturedOutput output) {
 		this.contextRunner.withUserConfiguration(TestController.class)
-			.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class, ObservationAutoConfiguration.class,
-					WebFluxAutoConfiguration.class))
-			.withPropertyValues("management.metrics.web.server.max-uri-tags=2",
-					"management.observations.http.server.requests.name=my.http.server.requests")
-			.run((context) -> {
-				MeterRegistry registry = getInitializedMeterRegistry(context, "my.http.server.requests");
-				assertThat(registry.get("my.http.server.requests").meters()).hasSizeLessThanOrEqualTo(2);
-				assertThat(output).contains("Reached the maximum number of URI tags for 'my.http.server.requests'");
-			});
+				.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class, ObservationAutoConfiguration.class,
+						WebFluxAutoConfiguration.class))
+				.withPropertyValues("management.metrics.web.server.max-uri-tags=2",
+						"management.observations.http.server.requests.name=my.http.server.requests")
+				.run((context) -> {
+					MeterRegistry registry = getInitializedMeterRegistry(context);
+					assertThat(registry.get("my.http.server.requests").meters()).hasSizeLessThanOrEqualTo(2);
+					assertThat(output).contains("Reached the maximum number of URI tags for 'my.http.server.requests'");
+				});
+	}
+
+	@Test
+	void whenAnActuatorEndpointIsCalledObservationsShouldBeRecorded() {
+		this.contextRunner.withUserConfiguration(TestController.class, TestObservationRegistryConfiguration.class)
+				.withConfiguration(AutoConfigurations.of(InfoEndpointAutoConfiguration.class,
+						WebFluxAutoConfiguration.class, HttpHandlerAutoConfiguration.class, EndpointAutoConfiguration.class,
+						WebEndpointAutoConfiguration.class, WebFluxEndpointManagementContextConfiguration.class,
+						MetricsAutoConfiguration.class, ObservationAutoConfiguration.class))
+				.withPropertyValues("management.endpoints.web.exposure.include=info")
+				.run((context) -> {
+					TestObservationRegistry observationRegistry = getInitializedTestObservationRegistry(context, "/test0",
+							"/actuator/info");
+					TestObservationRegistryAssert.assertThat(observationRegistry)
+							.hasNumberOfObservationsWithNameEqualTo("http.server.requests", 2)
+							.hasAnObservationWithAKeyValue("http.url", "/test0")
+							.hasAnObservationWithAKeyValue("http.url", "/actuator/info");
+				});
+	}
+
+	@Test
+	void whenActuatorObservationsEnabledObservationsShouldBeRecorded() {
+		this.contextRunner.withUserConfiguration(TestController.class, TestObservationRegistryConfiguration.class)
+				.withConfiguration(AutoConfigurations.of(InfoEndpointAutoConfiguration.class,
+						WebFluxAutoConfiguration.class, HttpHandlerAutoConfiguration.class, EndpointAutoConfiguration.class,
+						WebEndpointAutoConfiguration.class, WebFluxEndpointManagementContextConfiguration.class,
+						MetricsAutoConfiguration.class, ObservationAutoConfiguration.class))
+				.withPropertyValues("management.endpoints.web.exposure.include=info",
+						"management.observations.http.server.actuator.enabled=true")
+				.run((context) -> {
+					TestObservationRegistry observationRegistry = getInitializedTestObservationRegistry(context, "/test0",
+							"/actuator/info");
+					TestObservationRegistryAssert.assertThat(observationRegistry)
+							.hasNumberOfObservationsWithNameEqualTo("http.server.requests", 2)
+							.hasAnObservationWithAKeyValue("http.url", "/test0")
+							.hasAnObservationWithAKeyValue("http.url", "/actuator/info");
+				});
+	}
+
+	@Test
+	void whenActuatorObservationsDisabledObservationsShouldNotBeRecorded() {
+		this.contextRunner.withUserConfiguration(TestController.class, TestObservationRegistryConfiguration.class)
+				.withConfiguration(AutoConfigurations.of(InfoEndpointAutoConfiguration.class,
+						WebFluxAutoConfiguration.class, HttpHandlerAutoConfiguration.class, EndpointAutoConfiguration.class,
+						WebEndpointAutoConfiguration.class, WebFluxEndpointManagementContextConfiguration.class,
+						MetricsAutoConfiguration.class, ObservationAutoConfiguration.class))
+				.withPropertyValues("management.endpoints.web.exposure.include=info",
+						"management.observations.http.server.actuator.enabled=false")
+				.run((context) -> {
+					assertThat(context).hasBean("actuatorWebEndpointObservationPredicate");
+					TestObservationRegistry observationRegistry = getInitializedTestObservationRegistry(context, "/test0",
+							"/actuator/info");
+					TestObservationRegistryAssert.assertThat(observationRegistry)
+							.hasNumberOfObservationsWithNameEqualTo("http.server.requests", 1)
+							.hasAnObservationWithAKeyValue("http.url", "/test0");
+				});
+	}
+
+	@Test
+	void whenActuatorObservationsDisabledObservationsShouldNotBeRecordedUsingCustomEndpointBasePath() {
+		this.contextRunner.withUserConfiguration(TestController.class, TestObservationRegistryConfiguration.class)
+				.withConfiguration(AutoConfigurations.of(InfoEndpointAutoConfiguration.class,
+						WebFluxAutoConfiguration.class, HttpHandlerAutoConfiguration.class, EndpointAutoConfiguration.class,
+						WebEndpointAutoConfiguration.class, WebFluxEndpointManagementContextConfiguration.class,
+						MetricsAutoConfiguration.class, ObservationAutoConfiguration.class))
+				.withPropertyValues("management.endpoints.web.exposure.include=info",
+						"management.observations.http.server.actuator.enabled=false",
+						"management.endpoints.web.base-path=/management")
+				.run((context) -> {
+					assertThat(context).hasBean("actuatorWebEndpointObservationPredicate");
+					TestObservationRegistry observationRegistry = getInitializedTestObservationRegistry(context, "/test0",
+							"/management/info");
+					TestObservationRegistryAssert.assertThat(observationRegistry)
+							.hasNumberOfObservationsWithNameEqualTo("http.server.requests", 1)
+							.hasAnObservationWithAKeyValue("http.url", "/test0");
+				});
+	}
+
+	/**
+	 * Due to limitations in {@code WebTestClient}, these tests need to start a real
+	 * webserver and utilize a real http client with a real http request.
+	 */
+	@Test
+	void whenActuatorObservationsDisabledObservationsShouldNotBeRecordedUsingCustomWebfluxBasePath() {
+		new ReactiveWebApplicationContextRunner(AnnotationConfigReactiveWebServerApplicationContext::new)
+				.with(MetricsRun.simple())
+				.withConfiguration(AutoConfigurations.of(WebFluxAutoConfiguration.class, HttpHandlerAutoConfiguration.class,
+						ReactiveWebServerFactoryAutoConfiguration.class, InfoEndpointAutoConfiguration.class,
+						EndpointAutoConfiguration.class, WebEndpointAutoConfiguration.class,
+						WebFluxEndpointManagementContextConfiguration.class, MetricsAutoConfiguration.class,
+						ObservationAutoConfiguration.class, WebFluxObservationAutoConfiguration.class))
+				.withUserConfiguration(TestController.class, TestObservationRegistryConfiguration.class)
+				.withPropertyValues("server.port=0", "management.endpoints.web.exposure.include=info",
+						"management.observations.http.server.actuator.enabled=false", "spring.webflux.base-path=/test-path")
+				.run((context) -> {
+					assertThat(context).hasBean("actuatorWebEndpointObservationPredicate");
+					WebTestClient client = createWebTestClientForLocalPort(context);
+					TestObservationRegistry observationRegistry = getInitializedTestObservationRegistry(context, client,
+							"/test-path/test0", "/test-path/actuator/info");
+					TestObservationRegistryAssert.assertThat(observationRegistry)
+							.hasNumberOfObservationsWithNameEqualTo("http.server.requests", 1)
+							.hasAnObservationWithAKeyValue("http.url", "/test-path/test0");
+				});
+	}
+
+	/**
+	 * Due to limitations in {@code WebTestClient}, these tests need to start a real
+	 * webserver and utilize a real http client with a real http request.
+	 */
+	@Test
+	void whenActuatorObservationsDisabledObservationsShouldNotBeRecordedUsingCustomWebfluxBasePathAndCustomEndpointBasePath() {
+		new ReactiveWebApplicationContextRunner(AnnotationConfigReactiveWebServerApplicationContext::new)
+				.with(MetricsRun.simple())
+				.withConfiguration(AutoConfigurations.of(WebFluxAutoConfiguration.class, HttpHandlerAutoConfiguration.class,
+						ReactiveWebServerFactoryAutoConfiguration.class, InfoEndpointAutoConfiguration.class,
+						EndpointAutoConfiguration.class, WebEndpointAutoConfiguration.class,
+						WebFluxEndpointManagementContextConfiguration.class, MetricsAutoConfiguration.class,
+						ObservationAutoConfiguration.class, WebFluxObservationAutoConfiguration.class))
+				.withUserConfiguration(TestController.class, TestObservationRegistryConfiguration.class)
+				.withPropertyValues("server.port=0", "management.endpoints.web.exposure.include=info",
+						"management.observations.http.server.actuator.enabled=false", "spring.webflux.base-path=/test-path",
+						"management.endpoints.web.base-path=/management")
+				.run((context) -> {
+					assertThat(context).hasBean("actuatorWebEndpointObservationPredicate");
+					WebTestClient client = createWebTestClientForLocalPort(context);
+					TestObservationRegistry observationRegistry = getInitializedTestObservationRegistry(context, client,
+							"/test-path/test0", "/test-path/management/info");
+					TestObservationRegistryAssert.assertThat(observationRegistry)
+							.hasNumberOfObservationsWithNameEqualTo("http.server.requests", 1)
+							.hasAnObservationWithAKeyValue("http.url", "/test-path/test0");
+				});
 	}
 
 	@Test
 	void shouldNotDenyNorLogIfMaxUrisIsNotReached(CapturedOutput output) {
 		this.contextRunner.withUserConfiguration(TestController.class)
-			.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class, ObservationAutoConfiguration.class,
-					WebFluxAutoConfiguration.class))
-			.withPropertyValues("management.metrics.web.server.max-uri-tags=5")
-			.run((context) -> {
-				MeterRegistry registry = getInitializedMeterRegistry(context);
-				assertThat(registry.get("http.server.requests").meters()).hasSize(3);
-				assertThat(output).doesNotContain("Reached the maximum number of URI tags for 'http.server.requests'");
-			});
+				.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class, ObservationAutoConfiguration.class,
+						WebFluxAutoConfiguration.class))
+				.withPropertyValues("management.metrics.web.server.max-uri-tags=5")
+				.run((context) -> {
+					MeterRegistry registry = getInitializedMeterRegistry(context);
+					assertThat(registry.get("http.server.requests").meters()).hasSize(3);
+					assertThat(output).doesNotContain("Reached the maximum number of URI tags for 'http.server.requests'");
+				});
 	}
 
-	private MeterRegistry getInitializedMeterRegistry(AssertableReactiveWebApplicationContext context) {
-		return getInitializedMeterRegistry(context, "http.server.requests");
+	private MeterRegistry getInitializedMeterRegistry(AssertableReactiveWebApplicationContext context)
+			throws Exception {
+		return getInitializedMeterRegistry(context, "/test0", "/test1", "/test2");
 	}
 
-	private MeterRegistry getInitializedMeterRegistry(AssertableReactiveWebApplicationContext context,
-			String metricName) {
-		MeterRegistry meterRegistry = context.getBean(MeterRegistry.class);
-		meterRegistry.timer(metricName, "uri", "/test0").record(Duration.of(500, ChronoUnit.SECONDS));
-		meterRegistry.timer(metricName, "uri", "/test1").record(Duration.of(500, ChronoUnit.SECONDS));
-		meterRegistry.timer(metricName, "uri", "/test2").record(Duration.of(500, ChronoUnit.SECONDS));
-		return meterRegistry;
+	private MeterRegistry getInitializedMeterRegistry(AssertableReactiveWebApplicationContext context, String... urls) {
+		assertThat(context).hasSingleBean(ServerHttpObservationFilter.class);
+		WebTestClient client = WebTestClient.bindToApplicationContext(context).build();
+		for (String url : urls) {
+			client.get().uri(url).exchange().expectStatus().isOk();
+		}
+		return context.getBean(MeterRegistry.class);
+	}
+
+	private TestObservationRegistry getInitializedTestObservationRegistry(
+			AssertableReactiveWebApplicationContext context, String... urls) {
+		WebTestClient client = WebTestClient.bindToApplicationContext(context).configureClient().build();
+		return getInitializedTestObservationRegistry(context, client, urls);
+	}
+
+	private TestObservationRegistry getInitializedTestObservationRegistry(
+			AssertableReactiveWebApplicationContext context, WebTestClient client, String... urls) {
+		assertThat(context).hasSingleBean(ServerHttpObservationFilter.class);
+		for (String url : urls) {
+			client.get().uri(url).exchange().expectStatus().isOk();
+		}
+		return context.getBean(TestObservationRegistry.class);
+	}
+
+	private WebTestClient createWebTestClientForLocalPort(AssertableReactiveWebApplicationContext context) {
+		int port = ((AnnotationConfigReactiveWebServerApplicationContext) context.getSourceApplicationContext())
+				.getWebServer()
+				.getPort();
+		return WebTestClient.bindToServer().baseUrl("http://localhost:" + port).build();
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class TestObservationRegistryConfiguration {
+
+		@Bean
+		ObservationRegistry observationRegistry() {
+			return TestObservationRegistry.create();
+		}
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class CustomConventionConfiguration {
+
+		@Bean
+		CustomConvention customConvention() {
+			return new CustomConvention();
+		}
+
+	}
+
+	static class CustomConvention extends DefaultServerRequestObservationConvention {
+
+	}
+
+	@Order(Ordered.HIGHEST_PRECEDENCE)
+	static class FirstWebFilter implements WebFilter {
+
+		@Override
+		public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+			return chain.filter(exchange);
+		}
+
+	}
+
+	@Order(Ordered.HIGHEST_PRECEDENCE + 2)
+	static class ThirdWebFilter implements WebFilter {
+
+		@Override
+		public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+			return chain.filter(exchange);
+		}
+
 	}
 
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/observation/web/reactive/WebFluxObservationAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/observation/web/reactive/WebFluxObservationAutoConfigurationTests.java
@@ -64,8 +64,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Madhura Bhave
  * @author Jonatan Ivanov
  */
-@ExtendWith(OutputCaptureExtension.class)
-@SuppressWarnings("removal")
 class WebFluxObservationAutoConfigurationTests {
 
 	private final ReactiveWebApplicationContextRunner contextRunner = new ReactiveWebApplicationContextRunner()
@@ -73,12 +71,10 @@ class WebFluxObservationAutoConfigurationTests {
 			.withConfiguration(
 					AutoConfigurations.of(ObservationAutoConfiguration.class, WebFluxObservationAutoConfiguration.class));
 
-	@Test
 	void shouldProvideWebFluxObservationFilter() {
 		this.contextRunner.run((context) -> assertThat(context).hasSingleBean(ServerHttpObservationFilter.class));
 	}
 
-	@Test
 	void shouldProvideWebFluxObservationFilterOrdered() {
 		this.contextRunner.withBean(FirstWebFilter.class).withBean(ThirdWebFilter.class).run((context) -> {
 			List<WebFilter> webFilters = context.getBeanProvider(WebFilter.class).orderedStream().toList();
@@ -88,7 +84,6 @@ class WebFluxObservationAutoConfigurationTests {
 		});
 	}
 
-	@Test
 	void shouldUseCustomConventionWhenAvailable() {
 		this.contextRunner.withUserConfiguration(CustomConventionConfiguration.class).run((context) -> {
 			assertThat(context).hasSingleBean(ServerHttpObservationFilter.class);
@@ -98,7 +93,6 @@ class WebFluxObservationAutoConfigurationTests {
 		});
 	}
 
-	@Test
 	void afterMaxUrisReachedFurtherUrisAreDenied(CapturedOutput output) {
 		this.contextRunner.withUserConfiguration(TestController.class)
 				.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class, ObservationAutoConfiguration.class,
@@ -111,7 +105,6 @@ class WebFluxObservationAutoConfigurationTests {
 				});
 	}
 
-	@Test
 	void afterMaxUrisReachedFurtherUrisAreDeniedWhenUsingCustomObservationName(CapturedOutput output) {
 		this.contextRunner.withUserConfiguration(TestController.class)
 				.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class, ObservationAutoConfiguration.class,
@@ -125,7 +118,6 @@ class WebFluxObservationAutoConfigurationTests {
 				});
 	}
 
-	@Test
 	void whenAnActuatorEndpointIsCalledObservationsShouldBeRecorded() {
 		this.contextRunner.withUserConfiguration(TestController.class, TestObservationRegistryConfiguration.class)
 				.withConfiguration(AutoConfigurations.of(InfoEndpointAutoConfiguration.class,
@@ -143,7 +135,6 @@ class WebFluxObservationAutoConfigurationTests {
 				});
 	}
 
-	@Test
 	void whenActuatorObservationsEnabledObservationsShouldBeRecorded() {
 		this.contextRunner.withUserConfiguration(TestController.class, TestObservationRegistryConfiguration.class)
 				.withConfiguration(AutoConfigurations.of(InfoEndpointAutoConfiguration.class,
@@ -162,7 +153,6 @@ class WebFluxObservationAutoConfigurationTests {
 				});
 	}
 
-	@Test
 	void whenActuatorObservationsDisabledObservationsShouldNotBeRecorded() {
 		this.contextRunner.withUserConfiguration(TestController.class, TestObservationRegistryConfiguration.class)
 				.withConfiguration(AutoConfigurations.of(InfoEndpointAutoConfiguration.class,
@@ -181,7 +171,6 @@ class WebFluxObservationAutoConfigurationTests {
 				});
 	}
 
-	@Test
 	void whenActuatorObservationsDisabledObservationsShouldNotBeRecordedUsingCustomEndpointBasePath() {
 		this.contextRunner.withUserConfiguration(TestController.class, TestObservationRegistryConfiguration.class)
 				.withConfiguration(AutoConfigurations.of(InfoEndpointAutoConfiguration.class,
@@ -201,11 +190,7 @@ class WebFluxObservationAutoConfigurationTests {
 				});
 	}
 
-	/**
-	 * Due to limitations in {@code WebTestClient}, these tests need to start a real
-	 * webserver and utilize a real http client with a real http request.
-	 */
-	@Test
+
 	void whenActuatorObservationsDisabledObservationsShouldNotBeRecordedUsingCustomWebfluxBasePath() {
 		new ReactiveWebApplicationContextRunner(AnnotationConfigReactiveWebServerApplicationContext::new)
 				.with(MetricsRun.simple())
@@ -232,7 +217,6 @@ class WebFluxObservationAutoConfigurationTests {
 	 * Due to limitations in {@code WebTestClient}, these tests need to start a real
 	 * webserver and utilize a real http client with a real http request.
 	 */
-	@Test
 	void whenActuatorObservationsDisabledObservationsShouldNotBeRecordedUsingCustomWebfluxBasePathAndCustomEndpointBasePath() {
 		new ReactiveWebApplicationContextRunner(AnnotationConfigReactiveWebServerApplicationContext::new)
 				.with(MetricsRun.simple())
@@ -256,7 +240,6 @@ class WebFluxObservationAutoConfigurationTests {
 				});
 	}
 
-	@Test
 	void shouldNotDenyNorLogIfMaxUrisIsNotReached(CapturedOutput output) {
 		this.contextRunner.withUserConfiguration(TestController.class)
 				.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class, ObservationAutoConfiguration.class,
@@ -304,49 +287,4 @@ class WebFluxObservationAutoConfigurationTests {
 				.getPort();
 		return WebTestClient.bindToServer().baseUrl("http://localhost:" + port).build();
 	}
-
-	@Configuration(proxyBeanMethods = false)
-	static class TestObservationRegistryConfiguration {
-
-		@Bean
-		ObservationRegistry observationRegistry() {
-			return TestObservationRegistry.create();
-		}
-
-	}
-
-	@Configuration(proxyBeanMethods = false)
-	static class CustomConventionConfiguration {
-
-		@Bean
-		CustomConvention customConvention() {
-			return new CustomConvention();
-		}
-
-	}
-
-	static class CustomConvention extends DefaultServerRequestObservationConvention {
-
-	}
-
-	@Order(Ordered.HIGHEST_PRECEDENCE)
-	static class FirstWebFilter implements WebFilter {
-
-		@Override
-		public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
-			return chain.filter(exchange);
-		}
-
-	}
-
-	@Order(Ordered.HIGHEST_PRECEDENCE + 2)
-	static class ThirdWebFilter implements WebFilter {
-
-		@Override
-		public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
-			return chain.filter(exchange);
-		}
-
-	}
-
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/observation/web/servlet/WebMvcObservationAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/observation/web/servlet/WebMvcObservationAutoConfigurationTests.java
@@ -66,7 +66,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Chanhyeong LEE
  * @author Jonatan Ivanov
  */
-@ExtendWith(OutputCaptureExtension.class)
 class WebMvcObservationAutoConfigurationTests {
 
 	private final WebApplicationContextRunner contextRunner = new WebApplicationContextRunner()
@@ -74,14 +73,12 @@ class WebMvcObservationAutoConfigurationTests {
 			.withConfiguration(AutoConfigurations.of(ObservationAutoConfiguration.class))
 			.withConfiguration(AutoConfigurations.of(WebMvcObservationAutoConfiguration.class));
 
-	@Test
 	void backsOffWhenMeterRegistryIsMissing() {
 		new WebApplicationContextRunner()
 				.withConfiguration(AutoConfigurations.of(WebMvcObservationAutoConfiguration.class))
 				.run((context) -> assertThat(context).doesNotHaveBean(FilterRegistrationBean.class));
 	}
 
-	@Test
 	void definesFilterWhenRegistryIsPresent() {
 		this.contextRunner.run((context) -> {
 			assertThat(context).hasSingleBean(FilterRegistrationBean.class);
@@ -90,7 +87,6 @@ class WebMvcObservationAutoConfigurationTests {
 		});
 	}
 
-	@Test
 	void customConventionWhenPresent() {
 		this.contextRunner.withUserConfiguration(CustomConventionConfiguration.class)
 				.run((context) -> assertThat(context.getBean(FilterRegistrationBean.class).getFilter())
@@ -98,7 +94,6 @@ class WebMvcObservationAutoConfigurationTests {
 						.isInstanceOf(CustomConvention.class));
 	}
 
-	@Test
 	void filterRegistrationHasExpectedDispatcherTypesAndOrder() {
 		this.contextRunner.run((context) -> {
 			FilterRegistrationBean<?> registration = context.getBean(FilterRegistrationBean.class);
@@ -108,7 +103,6 @@ class WebMvcObservationAutoConfigurationTests {
 		});
 	}
 
-	@Test
 	void filterRegistrationBacksOffWithAnotherServerHttpObservationFilterRegistration() {
 		this.contextRunner.withUserConfiguration(TestServerHttpObservationFilterRegistrationConfiguration.class)
 				.run((context) -> {
@@ -118,26 +112,22 @@ class WebMvcObservationAutoConfigurationTests {
 				});
 	}
 
-	@Test
 	void filterRegistrationBacksOffWithAnotherServerHttpObservationFilter() {
 		this.contextRunner.withUserConfiguration(TestServerHttpObservationFilterConfiguration.class)
 				.run((context) -> assertThat(context).doesNotHaveBean(FilterRegistrationBean.class)
 						.hasSingleBean(ServerHttpObservationFilter.class));
 	}
 
-	@Test
 	void filterRegistrationDoesNotBackOffWithOtherFilterRegistration() {
 		this.contextRunner.withUserConfiguration(TestFilterRegistrationConfiguration.class)
 				.run((context) -> assertThat(context).hasBean("testFilter").hasBean("webMvcObservationFilter"));
 	}
 
-	@Test
 	void filterRegistrationDoesNotBackOffWithOtherFilter() {
 		this.contextRunner.withUserConfiguration(TestFilterConfiguration.class)
 				.run((context) -> assertThat(context).hasBean("testFilter").hasBean("webMvcObservationFilter"));
 	}
 
-	@Test
 	void afterMaxUrisReachedFurtherUrisAreDenied(CapturedOutput output) {
 		this.contextRunner.withUserConfiguration(TestController.class)
 				.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class, ObservationAutoConfiguration.class,
@@ -150,7 +140,6 @@ class WebMvcObservationAutoConfigurationTests {
 				});
 	}
 
-	@Test
 	void afterMaxUrisReachedFurtherUrisAreDeniedWhenUsingCustomObservationName(CapturedOutput output) {
 		this.contextRunner.withUserConfiguration(TestController.class)
 				.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class, ObservationAutoConfiguration.class,
@@ -164,7 +153,6 @@ class WebMvcObservationAutoConfigurationTests {
 				});
 	}
 
-	@Test
 	void shouldNotDenyNorLogIfMaxUrisIsNotReached(CapturedOutput output) {
 		this.contextRunner.withUserConfiguration(TestController.class)
 				.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class, ObservationAutoConfiguration.class,
@@ -177,7 +165,6 @@ class WebMvcObservationAutoConfigurationTests {
 				});
 	}
 
-	@Test
 	void whenAnActuatorEndpointIsCalledObservationsShouldBeRecorded() {
 		this.contextRunner.withUserConfiguration(TestController.class, TestObservationRegistryConfiguration.class)
 				.withConfiguration(AutoConfigurations.of(InfoEndpointAutoConfiguration.class, WebMvcAutoConfiguration.class,
@@ -196,7 +183,6 @@ class WebMvcObservationAutoConfigurationTests {
 				});
 	}
 
-	@Test
 	void whenActuatorObservationsEnabledObservationsShouldBeRecorded() {
 		this.contextRunner.withUserConfiguration(TestController.class, TestObservationRegistryConfiguration.class)
 				.withConfiguration(AutoConfigurations.of(InfoEndpointAutoConfiguration.class, WebMvcAutoConfiguration.class,
@@ -216,7 +202,6 @@ class WebMvcObservationAutoConfigurationTests {
 				});
 	}
 
-	@Test
 	void whenActuatorObservationsDisabledObservationsShouldNotBeRecorded() {
 		this.contextRunner.withUserConfiguration(TestController.class, TestObservationRegistryConfiguration.class)
 				.withConfiguration(AutoConfigurations.of(InfoEndpointAutoConfiguration.class, WebMvcAutoConfiguration.class,
@@ -235,7 +220,6 @@ class WebMvcObservationAutoConfigurationTests {
 				});
 	}
 
-	@Test
 	void whenActuatorObservationsDisabledObservationsShouldNotBeRecordedUsingCustomEndpointBasePath() {
 		this.contextRunner.withUserConfiguration(TestController.class, TestObservationRegistryConfiguration.class)
 				.withConfiguration(AutoConfigurations.of(InfoEndpointAutoConfiguration.class, WebMvcAutoConfiguration.class,
@@ -255,7 +239,6 @@ class WebMvcObservationAutoConfigurationTests {
 				});
 	}
 
-	@Test
 	void whenActuatorObservationsDisabledObservationsShouldNotBeRecordedUsingCustomContextPath() {
 		this.contextRunner.withUserConfiguration(TestController.class, TestObservationRegistryConfiguration.class)
 				.withConfiguration(AutoConfigurations.of(InfoEndpointAutoConfiguration.class, WebMvcAutoConfiguration.class,
@@ -275,7 +258,6 @@ class WebMvcObservationAutoConfigurationTests {
 				});
 	}
 
-	@Test
 	void whenActuatorObservationsDisabledObservationsShouldNotBeRecordedUsingCustomServletPath() {
 		this.contextRunner.withUserConfiguration(TestController.class, TestObservationRegistryConfiguration.class)
 				.withConfiguration(AutoConfigurations.of(InfoEndpointAutoConfiguration.class, WebMvcAutoConfiguration.class,
@@ -295,7 +277,6 @@ class WebMvcObservationAutoConfigurationTests {
 				});
 	}
 
-	@Test
 	void whenActuatorObservationsDisabledObservationsShouldNotBeRecordedUsingCustomContextPathAndCustomServletPathAndCustomEndpointBasePath() {
 		this.contextRunner.withUserConfiguration(TestController.class, TestObservationRegistryConfiguration.class)
 				.withConfiguration(AutoConfigurations.of(InfoEndpointAutoConfiguration.class, WebMvcAutoConfiguration.class,
@@ -349,71 +330,4 @@ class WebMvcObservationAutoConfigurationTests {
 		}
 		return context.getBean(TestObservationRegistry.class);
 	}
-
-	@Configuration(proxyBeanMethods = false)
-	static class TestObservationRegistryConfiguration {
-
-		@Bean
-		ObservationRegistry observationRegistry() {
-			return TestObservationRegistry.create();
-		}
-
-	}
-
-	@Configuration(proxyBeanMethods = false)
-	static class TestServerHttpObservationFilterRegistrationConfiguration {
-
-		@Bean
-		@SuppressWarnings("unchecked")
-		FilterRegistrationBean<ServerHttpObservationFilter> testServerHttpObservationFilter() {
-			return mock(FilterRegistrationBean.class);
-		}
-
-	}
-
-	@Configuration(proxyBeanMethods = false)
-	static class TestServerHttpObservationFilterConfiguration {
-
-		@Bean
-		ServerHttpObservationFilter testServerHttpObservationFilter() {
-			return new ServerHttpObservationFilter(TestObservationRegistry.create());
-		}
-
-	}
-
-	@Configuration(proxyBeanMethods = false)
-	static class TestFilterRegistrationConfiguration {
-
-		@Bean
-		@SuppressWarnings("unchecked")
-		FilterRegistrationBean<Filter> testFilter() {
-			return mock(FilterRegistrationBean.class);
-		}
-
-	}
-
-	@Configuration(proxyBeanMethods = false)
-	static class TestFilterConfiguration {
-
-		@Bean
-		Filter testFilter() {
-			return mock(Filter.class);
-		}
-
-	}
-
-	@Configuration(proxyBeanMethods = false)
-	static class CustomConventionConfiguration {
-
-		@Bean
-		CustomConvention customConvention() {
-			return new CustomConvention();
-		}
-
-	}
-
-	static class CustomConvention extends DefaultServerRequestObservationConvention {
-
-	}
-
 }

--- a/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/observation/web/servlet/WebMvcObservationAutoConfigurationTests.java
+++ b/spring-boot-project/spring-boot-actuator-autoconfigure/src/test/java/org/springframework/boot/actuate/autoconfigure/observation/web/servlet/WebMvcObservationAutoConfigurationTests.java
@@ -19,17 +19,24 @@ package org.springframework.boot.actuate.autoconfigure.observation.web.servlet;
 import java.util.EnumSet;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.tck.TestObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistryAssert;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.Filter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.servlet.WebMvcEndpointManagementContextConfiguration;
+import org.springframework.boot.actuate.autoconfigure.info.InfoEndpointAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.test.MetricsRun;
 import org.springframework.boot.actuate.autoconfigure.metrics.web.TestController;
 import org.springframework.boot.actuate.autoconfigure.observation.ObservationAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.web.servlet.DispatcherServletAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.servlet.WebMvcAutoConfiguration;
 import org.springframework.boot.test.context.assertj.AssertableWebApplicationContext;
 import org.springframework.boot.test.context.runner.WebApplicationContextRunner;
@@ -57,20 +64,21 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Tadaya Tsuyukubo
  * @author Madhura Bhave
  * @author Chanhyeong LEE
+ * @author Jonatan Ivanov
  */
 @ExtendWith(OutputCaptureExtension.class)
 class WebMvcObservationAutoConfigurationTests {
 
 	private final WebApplicationContextRunner contextRunner = new WebApplicationContextRunner()
-		.with(MetricsRun.simple())
-		.withConfiguration(AutoConfigurations.of(ObservationAutoConfiguration.class))
-		.withConfiguration(AutoConfigurations.of(WebMvcObservationAutoConfiguration.class));
+			.with(MetricsRun.simple())
+			.withConfiguration(AutoConfigurations.of(ObservationAutoConfiguration.class))
+			.withConfiguration(AutoConfigurations.of(WebMvcObservationAutoConfiguration.class));
 
 	@Test
 	void backsOffWhenMeterRegistryIsMissing() {
 		new WebApplicationContextRunner()
-			.withConfiguration(AutoConfigurations.of(WebMvcObservationAutoConfiguration.class))
-			.run((context) -> assertThat(context).doesNotHaveBean(FilterRegistrationBean.class));
+				.withConfiguration(AutoConfigurations.of(WebMvcObservationAutoConfiguration.class))
+				.run((context) -> assertThat(context).doesNotHaveBean(FilterRegistrationBean.class));
 	}
 
 	@Test
@@ -78,16 +86,16 @@ class WebMvcObservationAutoConfigurationTests {
 		this.contextRunner.run((context) -> {
 			assertThat(context).hasSingleBean(FilterRegistrationBean.class);
 			assertThat(context.getBean(FilterRegistrationBean.class).getFilter())
-				.isInstanceOf(ServerHttpObservationFilter.class);
+					.isInstanceOf(ServerHttpObservationFilter.class);
 		});
 	}
 
 	@Test
 	void customConventionWhenPresent() {
 		this.contextRunner.withUserConfiguration(CustomConventionConfiguration.class)
-			.run((context) -> assertThat(context.getBean(FilterRegistrationBean.class).getFilter())
-				.extracting("observationConvention")
-				.isInstanceOf(CustomConvention.class));
+				.run((context) -> assertThat(context.getBean(FilterRegistrationBean.class).getFilter())
+						.extracting("observationConvention")
+						.isInstanceOf(CustomConvention.class));
 	}
 
 	@Test
@@ -103,70 +111,210 @@ class WebMvcObservationAutoConfigurationTests {
 	@Test
 	void filterRegistrationBacksOffWithAnotherServerHttpObservationFilterRegistration() {
 		this.contextRunner.withUserConfiguration(TestServerHttpObservationFilterRegistrationConfiguration.class)
-			.run((context) -> {
-				assertThat(context).hasSingleBean(FilterRegistrationBean.class);
-				assertThat(context.getBean(FilterRegistrationBean.class))
-					.isSameAs(context.getBean("testServerHttpObservationFilter"));
-			});
+				.run((context) -> {
+					assertThat(context).hasSingleBean(FilterRegistrationBean.class);
+					assertThat(context.getBean(FilterRegistrationBean.class))
+							.isSameAs(context.getBean("testServerHttpObservationFilter"));
+				});
 	}
 
 	@Test
 	void filterRegistrationBacksOffWithAnotherServerHttpObservationFilter() {
 		this.contextRunner.withUserConfiguration(TestServerHttpObservationFilterConfiguration.class)
-			.run((context) -> assertThat(context).doesNotHaveBean(FilterRegistrationBean.class)
-				.hasSingleBean(ServerHttpObservationFilter.class));
+				.run((context) -> assertThat(context).doesNotHaveBean(FilterRegistrationBean.class)
+						.hasSingleBean(ServerHttpObservationFilter.class));
 	}
 
 	@Test
 	void filterRegistrationDoesNotBackOffWithOtherFilterRegistration() {
 		this.contextRunner.withUserConfiguration(TestFilterRegistrationConfiguration.class)
-			.run((context) -> assertThat(context).hasBean("testFilter").hasBean("webMvcObservationFilter"));
+				.run((context) -> assertThat(context).hasBean("testFilter").hasBean("webMvcObservationFilter"));
 	}
 
 	@Test
 	void filterRegistrationDoesNotBackOffWithOtherFilter() {
 		this.contextRunner.withUserConfiguration(TestFilterConfiguration.class)
-			.run((context) -> assertThat(context).hasBean("testFilter").hasBean("webMvcObservationFilter"));
+				.run((context) -> assertThat(context).hasBean("testFilter").hasBean("webMvcObservationFilter"));
 	}
 
 	@Test
 	void afterMaxUrisReachedFurtherUrisAreDenied(CapturedOutput output) {
 		this.contextRunner.withUserConfiguration(TestController.class)
-			.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class, ObservationAutoConfiguration.class,
-					WebMvcAutoConfiguration.class))
-			.withPropertyValues("management.metrics.web.server.max-uri-tags=2")
-			.run((context) -> {
-				MeterRegistry registry = getInitializedMeterRegistry(context);
-				assertThat(registry.get("http.server.requests").meters()).hasSizeLessThanOrEqualTo(2);
-				assertThat(output).contains("Reached the maximum number of URI tags for 'http.server.requests'");
-			});
+				.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class, ObservationAutoConfiguration.class,
+						WebMvcAutoConfiguration.class))
+				.withPropertyValues("management.metrics.web.server.max-uri-tags=2")
+				.run((context) -> {
+					MeterRegistry registry = getInitializedMeterRegistry(context);
+					assertThat(registry.get("http.server.requests").meters()).hasSizeLessThanOrEqualTo(2);
+					assertThat(output).contains("Reached the maximum number of URI tags for 'http.server.requests'");
+				});
 	}
 
 	@Test
 	void afterMaxUrisReachedFurtherUrisAreDeniedWhenUsingCustomObservationName(CapturedOutput output) {
 		this.contextRunner.withUserConfiguration(TestController.class)
-			.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class, ObservationAutoConfiguration.class,
-					WebMvcAutoConfiguration.class))
-			.withPropertyValues("management.metrics.web.server.max-uri-tags=2",
-					"management.observations.http.server.requests.name=my.http.server.requests")
-			.run((context) -> {
-				MeterRegistry registry = getInitializedMeterRegistry(context);
-				assertThat(registry.get("my.http.server.requests").meters()).hasSizeLessThanOrEqualTo(2);
-				assertThat(output).contains("Reached the maximum number of URI tags for 'my.http.server.requests'");
-			});
+				.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class, ObservationAutoConfiguration.class,
+						WebMvcAutoConfiguration.class))
+				.withPropertyValues("management.metrics.web.server.max-uri-tags=2",
+						"management.observations.http.server.requests.name=my.http.server.requests")
+				.run((context) -> {
+					MeterRegistry registry = getInitializedMeterRegistry(context);
+					assertThat(registry.get("my.http.server.requests").meters()).hasSizeLessThanOrEqualTo(2);
+					assertThat(output).contains("Reached the maximum number of URI tags for 'my.http.server.requests'");
+				});
 	}
 
 	@Test
 	void shouldNotDenyNorLogIfMaxUrisIsNotReached(CapturedOutput output) {
 		this.contextRunner.withUserConfiguration(TestController.class)
-			.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class, ObservationAutoConfiguration.class,
-					WebMvcAutoConfiguration.class))
-			.withPropertyValues("management.metrics.web.server.max-uri-tags=5")
-			.run((context) -> {
-				MeterRegistry registry = getInitializedMeterRegistry(context);
-				assertThat(registry.get("http.server.requests").meters()).hasSize(3);
-				assertThat(output).doesNotContain("Reached the maximum number of URI tags for 'http.server.requests'");
-			});
+				.withConfiguration(AutoConfigurations.of(MetricsAutoConfiguration.class, ObservationAutoConfiguration.class,
+						WebMvcAutoConfiguration.class))
+				.withPropertyValues("management.metrics.web.server.max-uri-tags=5")
+				.run((context) -> {
+					MeterRegistry registry = getInitializedMeterRegistry(context);
+					assertThat(registry.get("http.server.requests").meters()).hasSize(3);
+					assertThat(output).doesNotContain("Reached the maximum number of URI tags for 'http.server.requests'");
+				});
+	}
+
+	@Test
+	void whenAnActuatorEndpointIsCalledObservationsShouldBeRecorded() {
+		this.contextRunner.withUserConfiguration(TestController.class, TestObservationRegistryConfiguration.class)
+				.withConfiguration(AutoConfigurations.of(InfoEndpointAutoConfiguration.class, WebMvcAutoConfiguration.class,
+						DispatcherServletAutoConfiguration.class, EndpointAutoConfiguration.class,
+						WebEndpointAutoConfiguration.class, WebMvcEndpointManagementContextConfiguration.class,
+						MetricsAutoConfiguration.class, ObservationAutoConfiguration.class))
+				.withPropertyValues("management.endpoints.web.exposure.include=info")
+				.run((context) -> {
+					assertThat(context).doesNotHaveBean("actuatorWebEndpointObservationPredicate");
+					TestObservationRegistry observationRegistry = getInitializedTestObservationRegistry(context, "/test0",
+							"/actuator/info");
+					TestObservationRegistryAssert.assertThat(observationRegistry)
+							.hasNumberOfObservationsWithNameEqualTo("http.server.requests", 2)
+							.hasAnObservationWithAKeyValue("http.url", "/test0")
+							.hasAnObservationWithAKeyValue("http.url", "/actuator/info");
+				});
+	}
+
+	@Test
+	void whenActuatorObservationsEnabledObservationsShouldBeRecorded() {
+		this.contextRunner.withUserConfiguration(TestController.class, TestObservationRegistryConfiguration.class)
+				.withConfiguration(AutoConfigurations.of(InfoEndpointAutoConfiguration.class, WebMvcAutoConfiguration.class,
+						DispatcherServletAutoConfiguration.class, EndpointAutoConfiguration.class,
+						WebEndpointAutoConfiguration.class, WebMvcEndpointManagementContextConfiguration.class,
+						MetricsAutoConfiguration.class, ObservationAutoConfiguration.class))
+				.withPropertyValues("management.endpoints.web.exposure.include=info",
+						"management.observations.http.server.actuator.enabled=true")
+				.run((context) -> {
+					assertThat(context).doesNotHaveBean("actuatorWebEndpointObservationPredicate");
+					TestObservationRegistry observationRegistry = getInitializedTestObservationRegistry(context, "/test0",
+							"/actuator/info");
+					TestObservationRegistryAssert.assertThat(observationRegistry)
+							.hasNumberOfObservationsWithNameEqualTo("http.server.requests", 2)
+							.hasAnObservationWithAKeyValue("http.url", "/test0")
+							.hasAnObservationWithAKeyValue("http.url", "/actuator/info");
+				});
+	}
+
+	@Test
+	void whenActuatorObservationsDisabledObservationsShouldNotBeRecorded() {
+		this.contextRunner.withUserConfiguration(TestController.class, TestObservationRegistryConfiguration.class)
+				.withConfiguration(AutoConfigurations.of(InfoEndpointAutoConfiguration.class, WebMvcAutoConfiguration.class,
+						DispatcherServletAutoConfiguration.class, EndpointAutoConfiguration.class,
+						WebEndpointAutoConfiguration.class, WebMvcEndpointManagementContextConfiguration.class,
+						MetricsAutoConfiguration.class, ObservationAutoConfiguration.class))
+				.withPropertyValues("management.endpoints.web.exposure.include=info",
+						"management.observations.http.server.actuator.enabled=false")
+				.run((context) -> {
+					assertThat(context).hasBean("actuatorWebEndpointObservationPredicate");
+					TestObservationRegistry observationRegistry = getInitializedTestObservationRegistry(context, "/test0",
+							"/actuator/info");
+					TestObservationRegistryAssert.assertThat(observationRegistry)
+							.hasNumberOfObservationsWithNameEqualTo("http.server.requests", 1)
+							.hasAnObservationWithAKeyValue("http.url", "/test0");
+				});
+	}
+
+	@Test
+	void whenActuatorObservationsDisabledObservationsShouldNotBeRecordedUsingCustomEndpointBasePath() {
+		this.contextRunner.withUserConfiguration(TestController.class, TestObservationRegistryConfiguration.class)
+				.withConfiguration(AutoConfigurations.of(InfoEndpointAutoConfiguration.class, WebMvcAutoConfiguration.class,
+						DispatcherServletAutoConfiguration.class, EndpointAutoConfiguration.class,
+						WebEndpointAutoConfiguration.class, WebMvcEndpointManagementContextConfiguration.class,
+						MetricsAutoConfiguration.class, ObservationAutoConfiguration.class))
+				.withPropertyValues("management.endpoints.web.exposure.include=info",
+						"management.observations.http.server.actuator.enabled=false",
+						"management.endpoints.web.base-path=/management")
+				.run((context) -> {
+					assertThat(context).hasBean("actuatorWebEndpointObservationPredicate");
+					TestObservationRegistry observationRegistry = getInitializedTestObservationRegistry(context, "/test0",
+							"/management/info");
+					TestObservationRegistryAssert.assertThat(observationRegistry)
+							.hasNumberOfObservationsWithNameEqualTo("http.server.requests", 1)
+							.hasAnObservationWithAKeyValue("http.url", "/test0");
+				});
+	}
+
+	@Test
+	void whenActuatorObservationsDisabledObservationsShouldNotBeRecordedUsingCustomContextPath() {
+		this.contextRunner.withUserConfiguration(TestController.class, TestObservationRegistryConfiguration.class)
+				.withConfiguration(AutoConfigurations.of(InfoEndpointAutoConfiguration.class, WebMvcAutoConfiguration.class,
+						DispatcherServletAutoConfiguration.class, EndpointAutoConfiguration.class,
+						WebEndpointAutoConfiguration.class, WebMvcEndpointManagementContextConfiguration.class,
+						MetricsAutoConfiguration.class, ObservationAutoConfiguration.class))
+				.withPropertyValues("management.endpoints.web.exposure.include=info",
+						"management.observations.http.server.actuator.enabled=false",
+						"server.servlet.context-path=/test-context")
+				.run((context) -> {
+					assertThat(context).hasBean("actuatorWebEndpointObservationPredicate");
+					TestObservationRegistry observationRegistry = getInitializedTestObservationRegistry("/test-context",
+							context, "/test-context/test0", "/test-context/actuator/info");
+					TestObservationRegistryAssert.assertThat(observationRegistry)
+							.hasNumberOfObservationsWithNameEqualTo("http.server.requests", 1)
+							.hasAnObservationWithAKeyValue("http.url", "/test-context/test0");
+				});
+	}
+
+	@Test
+	void whenActuatorObservationsDisabledObservationsShouldNotBeRecordedUsingCustomServletPath() {
+		this.contextRunner.withUserConfiguration(TestController.class, TestObservationRegistryConfiguration.class)
+				.withConfiguration(AutoConfigurations.of(InfoEndpointAutoConfiguration.class, WebMvcAutoConfiguration.class,
+						DispatcherServletAutoConfiguration.class, EndpointAutoConfiguration.class,
+						WebEndpointAutoConfiguration.class, WebMvcEndpointManagementContextConfiguration.class,
+						MetricsAutoConfiguration.class, ObservationAutoConfiguration.class))
+				.withPropertyValues("management.endpoints.web.exposure.include=info",
+						"management.observations.http.server.actuator.enabled=false",
+						"spring.mvc.servlet.path=/test-servlet")
+				.run((context) -> {
+					assertThat(context).hasBean("actuatorWebEndpointObservationPredicate");
+					TestObservationRegistry observationRegistry = getInitializedTestObservationRegistry("/test-servlet",
+							context, "/test-servlet/test0", "/test-servlet/actuator/info");
+					TestObservationRegistryAssert.assertThat(observationRegistry)
+							.hasNumberOfObservationsWithNameEqualTo("http.server.requests", 1)
+							.hasAnObservationWithAKeyValue("http.url", "/test-servlet/test0");
+				});
+	}
+
+	@Test
+	void whenActuatorObservationsDisabledObservationsShouldNotBeRecordedUsingCustomContextPathAndCustomServletPathAndCustomEndpointBasePath() {
+		this.contextRunner.withUserConfiguration(TestController.class, TestObservationRegistryConfiguration.class)
+				.withConfiguration(AutoConfigurations.of(InfoEndpointAutoConfiguration.class, WebMvcAutoConfiguration.class,
+						DispatcherServletAutoConfiguration.class, EndpointAutoConfiguration.class,
+						WebEndpointAutoConfiguration.class, WebMvcEndpointManagementContextConfiguration.class,
+						MetricsAutoConfiguration.class, ObservationAutoConfiguration.class))
+				.withPropertyValues("management.endpoints.web.exposure.include=info",
+						"management.observations.http.server.actuator.enabled=false",
+						"server.servlet.context-path=/test-context", "spring.mvc.servlet.path=/test-servlet",
+						"management.endpoints.web.base-path=/management")
+				.run((context) -> {
+					assertThat(context).hasBean("actuatorWebEndpointObservationPredicate");
+					TestObservationRegistry observationRegistry = getInitializedTestObservationRegistry(
+							"/test-context/test-servlet", context, "/test-context/test-servlet/test0",
+							"/test-context/test-servlet/management/info");
+					TestObservationRegistryAssert.assertThat(observationRegistry)
+							.hasNumberOfObservationsWithNameEqualTo("http.server.requests", 1)
+							.hasAnObservationWithAKeyValue("http.url", "/test-context/test-servlet/test0");
+				});
 	}
 
 	private MeterRegistry getInitializedMeterRegistry(AssertableWebApplicationContext context) throws Exception {
@@ -183,6 +331,33 @@ class WebMvcObservationAutoConfigurationTests {
 			mockMvc.perform(MockMvcRequestBuilders.get(url)).andExpect(status().isOk());
 		}
 		return context.getBean(MeterRegistry.class);
+	}
+
+	private TestObservationRegistry getInitializedTestObservationRegistry(AssertableWebApplicationContext context,
+			String... urls) throws Exception {
+		return getInitializedTestObservationRegistry("", context, urls);
+	}
+
+	private TestObservationRegistry getInitializedTestObservationRegistry(String contextPath,
+			AssertableWebApplicationContext context, String... urls) throws Exception {
+		assertThat(context).hasSingleBean(FilterRegistrationBean.class);
+		Filter filter = context.getBean(FilterRegistrationBean.class).getFilter();
+		assertThat(filter).isInstanceOf(ServerHttpObservationFilter.class);
+		MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(context).addFilters(filter).build();
+		for (String url : urls) {
+			mockMvc.perform(MockMvcRequestBuilders.get(url).contextPath(contextPath)).andExpect(status().isOk());
+		}
+		return context.getBean(TestObservationRegistry.class);
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class TestObservationRegistryConfiguration {
+
+		@Bean
+		ObservationRegistry observationRegistry() {
+			return TestObservationRegistry.create();
+		}
+
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/main/resources/application.properties
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-actuator/src/main/resources/application.properties
@@ -31,3 +31,11 @@ management.endpoints.migrate-legacy-ids=true
 
 management.endpoints.jackson.isolated-object-mapper=true
 spring.jackson.visibility.field=any
+
+#management.tracing.sampling.probability=1.0
+#management.observations.http.server.actuator.enabled=false
+#server.port=8080
+#management.server.port=8888
+#management.endpoints.web.base-path=/mgmt
+#spring.mvc.servlet.path=/serv
+#server.servlet.context-path=/ctx

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-webflux/build.gradle
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-webflux/build.gradle
@@ -8,6 +8,7 @@ description = "Spring Boot WebFlux smoke test"
 dependencies {
 	implementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-actuator"))
 	implementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-webflux"))
+	implementation 'io.micrometer:micrometer-tracing-bridge-brave'
 
 	testImplementation(project(":spring-boot-project:spring-boot-starters:spring-boot-starter-test"))
 	testImplementation("io.projectreactor:reactor-test")

--- a/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-webflux/src/main/resources/application.properties
+++ b/spring-boot-tests/spring-boot-smoke-tests/spring-boot-smoke-test-webflux/src/main/resources/application.properties
@@ -1,3 +1,11 @@
+spring.application.name=sample
 management.endpoints.web.exposure.include=*
 management.endpoints.jackson.isolated-object-mapper=true
 spring.jackson.visibility.field=any
+
+#management.tracing.sampling.probability=1.0
+#management.observations.http.server.actuator.enabled=false
+#server.port=8080
+#management.server.port=8888
+#management.endpoints.web.base-path=/mgmt
+#spring.webflux.base-path=/base


### PR DESCRIPTION
It seems there is a good amount of users who are registering an ObservationPredicate in order to disable Observations for /actuator/** endpoints, something like this:

@bean
ObservationPredicate actuatorServerContextPredicate() {
return (name, context) -> {
if (name.equals("http.server.requests") && context instanceof ServerRequestObservationContext serverContext) {
return !serverContext.getCarrier().getRequestURI().startsWith("");
}
return true;
};
}

I think this common use-case could be simplified by creating a similar bean (for mvc and webflux) and let the users to configure this using a single property.
